### PR TITLE
Make public all internal packages

### DIFF
--- a/packages/@hothouse/client-npm/package.json
+++ b/packages/@hothouse/client-npm/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@hothouse/client-npm",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.1.5",
   "description": "Handle npm packages with npm",
   "main": "dist/index.js",

--- a/packages/@hothouse/client-yarn/package.json
+++ b/packages/@hothouse/client-yarn/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@hothouse/client-yarn",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.1.5",
   "description": "Handle npm packages with Yarn",
   "main": "dist/index.js",

--- a/packages/@hothouse/monorepo-lerna/package.json
+++ b/packages/@hothouse/monorepo-lerna/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@hothouse/monorepo-lerna",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.1.5",
   "description": "Handle repository structure with Lerna",
   "main": "./dist/index.js",

--- a/packages/@hothouse/monorepo-yarn-workspaces/package.json
+++ b/packages/@hothouse/monorepo-yarn-workspaces/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@hothouse/monorepo-yarn-workspaces",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.1.5",
   "description": "Handle repository structure with Yarn workspaces",
   "main": "./dist/index.js",


### PR DESCRIPTION
It cannot install `hothouse` because

```
npm i -g hothouse
npm ERR! code E404
npm ERR! 404 Not Found: @hothouse/client-npm@^0.1.5

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/leko/.npm/_logs/2018-06-29T17_22_52_942Z-debug.log
```

<img width="566" alt="screen shot 2018-06-30 at 2 24 45" src="https://user-images.githubusercontent.com/1424963/42105868-00a0d052-7c0d-11e8-9412-b1e2fbc40257.png">
