### PR TITLE
Fix semver update

### DIFF
--- a/packages/hothouse/__tests__/Package.spec.js
+++ b/packages/hothouse/__tests__/Package.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 // @flow
 import assert from "assert";
-import Package from "../src/Package";
+import Package, { replaceSemver } from "../src/Package";
 
 test("Package can instantiate with valid package path", () => {
   const pkg = new Package("../package.json");
@@ -9,4 +9,14 @@ test("Package can instantiate with valid package path", () => {
 });
 test("Package cannot instantiate with invalid package path", () => {
   assert.throws(() => new Package("./not-exists-path.json"));
+});
+
+test("replaceSemver can replace exact semver", () => {
+  assert.equal(replaceSemver("1.2.3", "4.5.6"), "4.5.6");
+});
+test("replaceSemver can replace tilde semver range", () => {
+  assert.equal(replaceSemver("~0.11.3", "0.12.0"), "~0.12.0");
+});
+test("replaceSemver can replace hat semver range", () => {
+  assert.equal(replaceSemver("^1.13.1", "2.0.0"), "^2.0.0");
 });

--- a/packages/hothouse/__tests__/Package.spec.js
+++ b/packages/hothouse/__tests__/Package.spec.js
@@ -20,3 +20,12 @@ test("replaceSemver can replace tilde semver range", () => {
 test("replaceSemver can replace hat semver range", () => {
   assert.equal(replaceSemver("^1.13.1", "2.0.0"), "^2.0.0");
 });
+test("replaceSemver can replace semver range with prerelease (like Babel)", () => {
+  assert.equal(
+    replaceSemver("^7.0.0-beta.49", "7.0.0-beta.51"),
+    "^7.0.0-beta.51"
+  );
+});
+test("replaceSemver throws Error when too many diffs", () => {
+  assert.throws(() => replaceSemver("^1.0.0-beta.1", "1.0.0-beta.202"));
+});

--- a/packages/hothouse/src/Package.js
+++ b/packages/hothouse/src/Package.js
@@ -3,6 +3,14 @@ import fs from "fs";
 import semver from "semver";
 import type { Update } from "@hothouse/types";
 
+export const replaceSemver = (
+  fromVersion: string,
+  toVersion: string
+): string => {
+  const current = semver.coerce(fromVersion).version;
+  return fromVersion.replace(current, toVersion);
+};
+
 export default class Package {
   pkgJsonPath: string;
   pkgJson: Object;
@@ -17,9 +25,8 @@ export default class Package {
     const deps = update.dev
       ? this.pkgJson.devDependencies
       : this.pkgJson.dependencies;
-    const current = semver.coerce(deps[update.name]).version;
 
-    deps[update.name] = deps[update.name].replace(current, update.latest);
+    deps[update.name] = replaceSemver(deps[update.name], update.latest);
   }
 
   async save(): Promise<void> {


### PR DESCRIPTION
This PR fixed #23

- Supports prerelease version like `^1.0.0-beta.1`
- Supports simple prefix (`~`, `^`, `>`, `>=`, `<`, `<=`)
