### PR TITLE
Follow commonly named tags

### DIFF
--- a/packages/@hothouse/types/index.js
+++ b/packages/@hothouse/types/index.js
@@ -49,6 +49,11 @@ export interface Structure {
 export interface Hosting {
   match(repositoryUrl: string): Promise<boolean>;
   shaToTag(token: string, repositoryUrl: string, sha: string): Promise<string>;
+  tagExists(
+    token: string,
+    repositoryUrl: string,
+    tag: string
+  ): Promise<boolean>;
   tagToReleaseNote(
     token: string,
     repositoryUrl: string,

--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "hothouse",
-  "version": "0.1.32",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@octokit/rest": {
       "version": "15.9.2",

--- a/packages/hothouse/src/Engine.js
+++ b/packages/hothouse/src/Engine.js
@@ -18,6 +18,7 @@ import {
   createPullRequestMessage
 } from "./pullRequest";
 import git from "./git";
+import { ShaNotResolved } from "./errors";
 
 const debug = require("debug")("hothouse:Engine");
 
@@ -216,9 +217,27 @@ export default class Engine {
   ): Promise<?string> {
     const packageAnnotation = `${packageName}@${version}`;
     debug(`Try to fetch tag ${packageAnnotation}`);
+
     try {
       const meta = await this.packageManager.getPackageMeta(packageAnnotation);
       const hosting = await this.detectHosting(meta);
+
+      const commonTagNames = [`v${version}`, version];
+      for (let tag of commonTagNames) {
+        debug(`Check commonly named tag exists: ${tag}`);
+        if (await hosting.tagExists(token, meta.repository.url, tag)) {
+          debug(`Tag exists: ${tag}`);
+          return tag;
+        }
+        debug(`${tag} is not exists`);
+      }
+      if (!meta.gitHead) {
+        debug(
+          `gitHead is not specified so cannot resolve tag name: ${packageAnnotation}`
+        );
+        return null;
+      }
+      debug(`Resolve tag by commit sha: ${meta.gitHead}`);
       return await hosting.shaToTag(token, meta.repository.url, meta.gitHead);
     } catch (error) {
       debug(

--- a/packages/hothouse/src/Engine.js
+++ b/packages/hothouse/src/Engine.js
@@ -18,7 +18,6 @@ import {
   createPullRequestMessage
 } from "./pullRequest";
 import git from "./git";
-import { ShaNotResolved } from "./errors";
 
 const debug = require("debug")("hothouse:Engine");
 

--- a/packages/hothouse/src/Hosting/GitHub.js
+++ b/packages/hothouse/src/Hosting/GitHub.js
@@ -2,8 +2,8 @@
 import parse from "git-url-parse";
 import octokit from "@octokit/rest";
 import type { Hosting } from "@hothouse/types";
-
-const client = octokit();
+import { ShaNotResolved } from "../errors";
+import { getTagsQuery } from "./graphql";
 
 export const parseRepositoryUrl = (url: string): [string, string] => {
   const { owner, name } = parse(url);
@@ -15,17 +15,31 @@ export default class GitHub implements Hosting {
     return repositoryUrl.toLowerCase().includes("github");
   }
 
+  async tagExists(
+    token: string,
+    repositoryUrl: string,
+    tag: string
+  ): Promise<boolean> {
+    const client = this.prepare(token);
+    const [owner, repo] = parseRepositoryUrl(repositoryUrl);
+    // FIXME: Currently, get 100 tags order by commited date but it's not incomplete.
+    //        We shuold get all tags and compare it.
+    const { data } = await client.request({
+      method: "POST",
+      url: "/graphql",
+      query: getTagsQuery(owner, repo)
+    });
+
+    return data.data.repository.refs.nodes.some(({ name }) => name === tag);
+  }
+
   async shaToTag(
     token: string,
     repositoryUrl: string,
     sha: string
   ): Promise<string> {
+    const client = this.prepare(token);
     const [owner, repo] = parseRepositoryUrl(repositoryUrl);
-    // /repos/yargs/yargs/git/tags/57a39cb8fe5051b9d9bb87fb789cc0d6d2363ce6
-    client.authenticate({
-      type: "token",
-      token
-    });
 
     const PER_PAGE = 100;
     let page = 1;
@@ -45,7 +59,7 @@ export default class GitHub implements Hosting {
       }
       page++;
     }
-    throw new Error(`Cannot resolve sha: ${sha}`);
+    throw new ShaNotResolved(`Cannot resolve sha: ${sha}`);
   }
 
   async tagToReleaseNote(
@@ -53,6 +67,7 @@ export default class GitHub implements Hosting {
     repositoryUrl: string,
     tag: string
   ): Promise<?string> {
+    const client = this.prepare(token);
     const [owner, repo] = parseRepositoryUrl(repositoryUrl);
     try {
       return await client.repos.getReleaseByTag({ owner, repo, tag });
@@ -70,6 +85,7 @@ export default class GitHub implements Hosting {
     base: string,
     head: string
   ): Promise<string> {
+    const client = this.prepare(token);
     const [owner, repo] = parseRepositoryUrl(repositoryUrl);
     const result = await client.repos.compareCommits({
       owner,
@@ -88,6 +104,7 @@ export default class GitHub implements Hosting {
     title: string,
     body: string
   ): Promise<string> {
+    const client = this.prepare(token);
     const [owner, repo] = parseRepositoryUrl(repositoryUrl);
     const result = await client.pullRequests.create({
       owner,
@@ -104,8 +121,19 @@ export default class GitHub implements Hosting {
     token: string,
     repositoryUrl: string
   ): Promise<string> {
+    const client = this.prepare(token);
     const [owner, repo] = parseRepositoryUrl(repositoryUrl);
     const result = await client.repos.get({ owner, repo });
     return result.data.default_branch;
+  }
+
+  prepare(token: string) {
+    const client = octokit();
+    client.authenticate({
+      type: "token",
+      token
+    });
+
+    return client;
   }
 }

--- a/packages/hothouse/src/Hosting/GitHub.js
+++ b/packages/hothouse/src/Hosting/GitHub.js
@@ -2,7 +2,6 @@
 import parse from "git-url-parse";
 import octokit from "@octokit/rest";
 import type { Hosting } from "@hothouse/types";
-import { ShaNotResolved } from "../errors";
 import { getTagsQuery } from "./graphql";
 
 export const parseRepositoryUrl = (url: string): [string, string] => {
@@ -59,7 +58,7 @@ export default class GitHub implements Hosting {
       }
       page++;
     }
-    throw new ShaNotResolved(`Cannot resolve sha: ${sha}`);
+    throw new Error(`Cannot resolve sha: ${sha}`);
   }
 
   async tagToReleaseNote(

--- a/packages/hothouse/src/Hosting/UnknownHosting.js
+++ b/packages/hothouse/src/Hosting/UnknownHosting.js
@@ -6,6 +6,14 @@ export default class UnknownHosting implements Hosting {
     return true;
   }
 
+  async tagExists(
+    token: string,
+    repositoryUrl: string,
+    tag: string
+  ): Promise<boolean> {
+    return false;
+  }
+
   async shaToTag(
     token: string,
     repositoryUrl: string,

--- a/packages/hothouse/src/Hosting/graphql.js
+++ b/packages/hothouse/src/Hosting/graphql.js
@@ -1,0 +1,13 @@
+// @flow
+
+export const getTagsQuery = (owner: string, name: string) => `
+query {
+  repository(owner: "${owner}", name: "${name}") {
+    refs(refPrefix: "refs/tags/", first: 100, orderBy: {field: TAG_COMMIT_DATE, direction: DESC}) {
+      nodes {
+        name
+      }
+    }
+  }
+}
+`;

--- a/packages/hothouse/src/errors.js
+++ b/packages/hothouse/src/errors.js
@@ -1,3 +1,0 @@
-// @flow
-
-export class ShaNotResolved extends Error {}

--- a/packages/hothouse/src/errors.js
+++ b/packages/hothouse/src/errors.js
@@ -1,0 +1,3 @@
+// @flow
+
+export class ShaNotResolved extends Error {}


### PR DESCRIPTION
Fixed #44 

hothouse can support commonly named tags

- `v{pkg.version}` (ex. `v1.2.3-beta.39`)
- `{pkg.version}` (ex. `1.2.3-beta.39`)
