### PR TITLE
Update yargs to the latest version

### DIFF
--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -1,50 +1,7 @@
 {
-  "name": "hothouse",
-  "version": "0.4.2",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
-    "@hothouse/client-npm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hothouse/client-npm/-/client-npm-0.4.2.tgz",
-      "integrity": "sha512-ikCrsY+RaJ6YhdIT8wgp0gR8lFi9wiE54x5XRv/0TyfV6EUf4iW5Uzq7v2coS+v+5wFfEGGUZBuQ5WHEOCnyuw==",
-      "requires": {
-        "debug": "3.1.0"
-      }
-    },
-    "@hothouse/client-yarn": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hothouse/client-yarn/-/client-yarn-0.4.2.tgz",
-      "integrity": "sha512-yROVnLr7dtBawG0MjjTX29m9pB/3OR/zZCdtKpL1NPDN4f5/XKvF9Itd2LJk8/RH1XOtUjmj64c/KgUmP9bvxA==",
-      "requires": {
-        "@hothouse/monorepo-lerna": "0.4.2",
-        "@hothouse/monorepo-yarn-workspaces": "0.4.2",
-        "debug": "3.1.0"
-      }
-    },
-    "@hothouse/monorepo-lerna": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hothouse/monorepo-lerna/-/monorepo-lerna-0.4.2.tgz",
-      "integrity": "sha512-5rKSGkRVfhw7Kxe0FBTBeVL22cW6iImF8wdGzLlZVUm8moprP0ZEeopon4mBtABlyRPHsxk9WPjvv/0JiYsguA==",
-      "requires": {
-        "debug": "3.1.0",
-        "glob": "7.1.2"
-      }
-    },
-    "@hothouse/monorepo-yarn-workspaces": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hothouse/monorepo-yarn-workspaces/-/monorepo-yarn-workspaces-0.4.2.tgz",
-      "integrity": "sha512-CLXWfZ31Li625JSV81ofHIqjZwakrWLUYlWJVDikKr/iCLYqcXC11/x4tT/lYahxpNFxy032dTsumcp4VzdDLQ==",
-      "requires": {
-        "debug": "3.1.0",
-        "glob": "7.1.2"
-      }
-    },
-    "@hothouse/types": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@hothouse/types/-/types-0.4.2.tgz",
-      "integrity": "sha512-wKzouewFePJ3UtpOK+skXIg1ES2oDSJ4hjN7UmjEoQJ/E289u+KgaS9IJ3gjTqTCd99CPwXsD7X0IhgY6moG5A=="
-    },
     "@octokit/rest": {
       "version": "15.9.2",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.2.tgz",
@@ -225,9 +182,12 @@
       }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "requires": {
+        "xregexp": "4.0.0"
+      }
     },
     "detab": {
       "version": "2.0.1",
@@ -280,11 +240,11 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "fs.realpath": {
@@ -293,9 +253,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -489,11 +449,11 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "2.0.0",
+        "p-locate": "3.0.0",
         "path-exists": "3.0.0"
       }
     },
@@ -678,25 +638,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "2.0.0"
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "parse-entities": {
       "version": "1.1.2",
@@ -867,7 +827,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2"
       }
@@ -1188,15 +1147,20 @@
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -1204,28 +1168,28 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
       "requires": {
         "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
+        "decamelize": "2.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
         "os-locale": "2.1.0",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
         "string-width": "2.1.1",
         "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "y18n": "4.0.0",
+        "yargs-parser": "10.1.0"
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
         "camelcase": "4.1.0"
       }

--- a/packages/hothouse/package.json
+++ b/packages/hothouse/package.json
@@ -52,7 +52,7 @@
     "semver": "^5.5.0",
     "threads": "^0.12.0",
     "unified": "^7.0.0",
-    "yargs": "^11.0.0"
+    "yargs": "^12.0.1"
   },
   "babel": {
     "extends": "../../.babelrc"


### PR DESCRIPTION
## Version **12.0.1** of **yargs** was just published.

* Package: [repository](https://github.com/yargs/yargs.git), [npm](https://www.npmjs.com/package/yargs)
* Current Version: 11.1.0
* Dev: false
* [compare 11.1.0 to 12.0.1 diffs](https://github.com/yargs/yargs/compare/v11.1.0...v12.0.1)

The version(`12.0.1`) is **not covered** by your current version range(`^11.0.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: