### PR TITLE
Wrap all procedure into Promise.catch

### DIFF
--- a/packages/hothouse/src/Engine.js
+++ b/packages/hothouse/src/Engine.js
@@ -94,7 +94,6 @@ export default class Engine {
       concurrency: this.concurrency,
       reporter: this.reporter
     });
-
     try {
       await pool.configure(config);
 
@@ -181,9 +180,6 @@ export default class Engine {
       await this.reporter.reportApplyResult(directory, results);
 
       return results;
-    } catch (error) {
-      await this.reporter.reportError(error);
-      throw error;
     } finally {
       await pool.terminate();
     }

--- a/packages/hothouse/src/cli/index.js
+++ b/packages/hothouse/src/cli/index.js
@@ -10,6 +10,7 @@ runner({
   cwd: process.cwd(),
   gitImpl,
   reporter
-}).catch(() => {
+}).catch(async error => {
+  reporter.reportError(error);
   process.exit(1);
 });


### PR DESCRIPTION
Related: #91

- Move reporter.reportError from Engine#run to cli/index.js (the outermost catch)
