### PR TITLE
Report error when repository.url is not defined

### DIFF
--- a/packages/hothouse/__tests__/Package.spec.js
+++ b/packages/hothouse/__tests__/Package.spec.js
@@ -47,3 +47,20 @@ test("Package#getRepositoryHttpsUrl can resolve github shortcut format", () => {
     "https://github.com/Leko/hothouse.git"
   );
 });
+test("Package#getRepositoryHttpsUrl throws when repository.url is not defined with pkgJsonPath", () => {
+  const pkg = new Package("../package.json");
+  delete pkg.pkgJsonNormalized.repository;
+  assert.throws(
+    () => pkg.getRepositoryHttpsUrl(),
+    new RegExp(`repository.url is not defined in ../package.json`)
+  );
+});
+test("Package#getRepositoryHttpsUrl throws when repository.url is not defined without pkgJsonPath", () => {
+  const pkgJson = require("../package.json");
+  const pkg = new Package(pkgJson);
+  delete pkg.pkgJsonNormalized.repository;
+  assert.throws(
+    () => pkg.getRepositoryHttpsUrl(),
+    new RegExp(`repository.url is not defined in ${pkgJson.name}`)
+  );
+});

--- a/packages/hothouse/src/Package.js
+++ b/packages/hothouse/src/Package.js
@@ -38,6 +38,13 @@ export default class Package {
   }
 
   getRepositoryHttpsUrl(): string {
+    const { repository } = this.pkgJsonNormalized;
+    if (!repository || !repository.url) {
+      throw new Error(
+        `repository.url is not defined in ${this.pkgJsonPath ||
+          this.pkgJsonNormalized.name}`
+      );
+    }
     if (/^https:/.test(this.pkgJsonNormalized.repository.url)) {
       return this.pkgJsonNormalized.repository.url;
     }


### PR DESCRIPTION
An error occurred when repository.url is not defined in package.json of the current directory.

```
TypeError: Cannot read property 'url' of undefined
    at Package.getRepositoryHttpsUrl (/Users/leko/.ghq/github.com/Leko/hothouse/packages/hothouse/dist/Package.js:56:58)
    at detect (/Users/leko/.ghq/github.com/Leko/hothouse/packages/hothouse/dist/Hosting/index.js:29:29)
    at _default (/Users/leko/.ghq/github.com/Leko/hothouse/packages/hothouse/dist/tasks/configure.js:48:40)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
    at Function.Module.runMain (module.js:678:11)
    at startup (bootstrap_node.js:187:16)
    at bootstrap_node.js:608:3
```

It's not clear.
I changed output as below when repository.url is not defined:

```
Error: repository.url is not defined in /Users/leko/.ghq/github.com/xxx/package.json
```
