### PR TITLE
Update remark-html to the latest version

### DIFF
--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hothouse",
-  "version": "0.4.8",
+  "version": "0.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -296,17 +296,16 @@
       }
     },
     "hast-util-to-html": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
-      "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-4.0.1.tgz",
+      "integrity": "sha512-2emzwyf0xEsc4TBIPmDJmBttIw8R4SXAJiJZoiRR/s47ODYWgOqNoDbf2SJAbMbfNdFWMiCSOrI3OVnX6Qq2Mg==",
       "requires": {
         "ccount": "1.0.3",
         "comma-separated-tokens": "1.0.5",
         "hast-util-is-element": "1.0.1",
         "hast-util-whitespace": "1.0.1",
         "html-void-elements": "1.0.3",
-        "kebab-case": "1.0.0",
-        "property-information": "3.2.0",
+        "property-information": "4.1.0",
         "space-separated-tokens": "1.1.2",
         "stringify-entities": "1.3.2",
         "unist-util-is": "2.1.2",
@@ -437,11 +436,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
-    "kebab-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.0.tgz",
-      "integrity": "sha1-P55JkK3K0MaGwOcB92RYaPdfkes="
-    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -503,25 +497,25 @@
       }
     },
     "mdast-util-definitions": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
-      "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz",
+      "integrity": "sha512-P6wpRO8YVQ1iv30maMc93NLh7COvufglBE8/ldcOyYmk5EbfF0YeqlLgtqP/FOBU501Kqar1x5wYWwB3Nga74g==",
       "requires": {
         "unist-util-visit": "1.3.1"
       }
     },
     "mdast-util-to-hast": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.1.tgz",
-      "integrity": "sha512-+eimV/12kdg0/T0EEfcK7IsDbSu2auVm92z5jdSEQ3DHF2HiU4OHmX9ir5wpQajr73nwabdxrUoxREvW2zVFFw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-3.0.2.tgz",
+      "integrity": "sha512-YI8Ea3TFWEZrS31+6Q/d8ZYTOSDKM06IPc3l2+OMFX1o3JTG2mrztlmzDsUMwIXLWofEdTVl/WXBgRG6ddlU/A==",
       "requires": {
         "collapse-white-space": "1.0.4",
         "detab": "2.0.1",
-        "mdast-util-definitions": "1.2.2",
+        "mdast-util-definitions": "1.2.3",
         "mdurl": "1.0.1",
         "trim": "0.0.1",
         "trim-lines": "1.1.1",
-        "unist-builder": "1.0.2",
+        "unist-builder": "1.0.3",
         "unist-util-generated": "1.1.2",
         "unist-util-position": "3.0.1",
         "unist-util-visit": "1.3.1",
@@ -689,9 +683,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "property-information": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-3.2.0.tgz",
-      "integrity": "sha1-/RSDyPusYYCPX+NZ52k6H0ilgzE="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-4.1.0.tgz",
+      "integrity": "sha512-bv9oWK9kX47b1rpZoLdv21FGCUAWTOClpb/wsbz2unJtyrZg05h7JBhn4mDb20KCG1jF/cbIdUa2IoYU/Wj4Hw==",
+      "requires": {
+        "xtend": "4.0.1"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -752,13 +749,13 @@
       }
     },
     "remark-html": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-7.0.0.tgz",
-      "integrity": "sha512-jqRzkZXCkM12gIY2ibMLTW41m7rfanliMTVQCFTezHJFsbH00YaTox/BX4gU+f/zCdzfhFJONtebFByvpMv37w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-8.0.0.tgz",
+      "integrity": "sha512-3V2391GL3hxKhrkzYOyfPpxJ6taIKLCfuLVqumeWQOk3H9nTtSQ8St8kMYkBVIEAquXN1chT83qJ/2lAW+dpEg==",
       "requires": {
         "hast-util-sanitize": "1.2.0",
-        "hast-util-to-html": "3.1.0",
-        "mdast-util-to-hast": "3.0.1",
+        "hast-util-to-html": "4.0.1",
+        "mdast-util-to-hast": "3.0.2",
         "xtend": "4.0.1"
       }
     },
@@ -996,9 +993,9 @@
       }
     },
     "unist-builder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
-      "integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.3.tgz",
+      "integrity": "sha512-/KB8GEaoeHRyIqClL+Kam+Y5NWJ6yEiPsAfv1M+O1p+aKGgjR89WwoEHKTyOj17L6kAlqtKpAgv2nWvdbQDEig==",
       "requires": {
         "object-assign": "4.1.1"
       }

--- a/packages/hothouse/package.json
+++ b/packages/hothouse/package.json
@@ -50,7 +50,7 @@
     "normalize-package-data": "^2.4.0",
     "remark": "^9.0.0",
     "remark-github": "^7.0.3",
-    "remark-html": "^7.0.0",
+    "remark-html": "^8.0.0",
     "remark-parse": "^5.0.0",
     "semver": "^5.5.0",
     "threads": "^0.12.0",


### PR DESCRIPTION
## Version **8.0.0** of **remark-html** was just published.

* Package: [repository](https://github.com/remarkjs/remark-html.git), [npm](https://www.npmjs.com/package/remark-html)
* Current Version: 7.0.0
* Dev: false


The version(`8.0.0`) is **not covered** by your current version range(`^7.0.0`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<ul>
<li><a href="https://github.com/Leko/hothouse/commit/df4703d"><code>df4703d</code></a> <a href="https://github.com/syntax-tree/hast-util-to-html/releases/tag/4.0.0">Update <code>hast-util-to-html</code></a></li>
<li><a href="https://github.com/Leko/hothouse/commit/871283e"><code>871283e</code></a> Refactor code-style</li>
<li><a href="https://github.com/Leko/hothouse/commit/c40853b"><code>c40853b</code></a> Add <code>Contribute</code> section to <code>readme.md</code></li>
<li><a href="https://github.com/Leko/hothouse/commit/a331e1e"><code>a331e1e</code></a> Migrate to <code>remarkjs</code></li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: