### PR TITLE
Update eslint-plugin-flowtype to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,9 +2011,9 @@
       "dev": true
     },
     "babel-eslint": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
-      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2034,12 +2034,12 @@
           }
         },
         "@babel/generator": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
-          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+          "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.0.0",
+            "@babel/types": "^7.1.3",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.10",
             "source-map": "^0.5.0",
@@ -2047,13 +2047,13 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
-          "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
           "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.0.0",
-            "@babel/template": "^7.0.0",
+            "@babel/template": "^7.1.0",
             "@babel/types": "^7.0.0"
           }
         },
@@ -2087,43 +2087,43 @@
           }
         },
         "@babel/parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
-          "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+          "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
-          "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+          "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.0.0",
-            "@babel/types": "^7.0.0"
+            "@babel/parser": "^7.1.2",
+            "@babel/types": "^7.1.2"
           }
         },
         "@babel/traverse": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
-          "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+          "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@babel/generator": "^7.0.0",
-            "@babel/helper-function-name": "^7.0.0",
+            "@babel/generator": "^7.1.3",
+            "@babel/helper-function-name": "^7.1.0",
             "@babel/helper-split-export-declaration": "^7.0.0",
-            "@babel/parser": "^7.0.0",
-            "@babel/types": "^7.0.0",
+            "@babel/parser": "^7.1.3",
+            "@babel/types": "^7.1.3",
             "debug": "^3.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.10"
           }
         },
         "@babel/types": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+          "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
           "dev": true,
           "requires": {
             "esutils": "^2.0.2",
@@ -4633,7 +4633,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5048,7 +5049,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5104,6 +5106,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5147,12 +5150,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^3.0.1",
     "eslint-config-standard": "^12.0.0",
-    "eslint-plugin-flowtype": "^2.49.3",
+    "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.8.0",


### PR DESCRIPTION
## Version **3.0.0** of **eslint-plugin-flowtype** was just published.

* Package: [repository](https://github.com/gajus/eslint-plugin-flowtype.git), [npm](https://www.npmjs.com/package/eslint-plugin-flowtype)
* Current Version: 2.49.3
* Dev: true
* [compare 2.49.3 to 3.0.0 diffs](https://github.com/gajus/eslint-plugin-flowtype/compare/v2.49.3...v3.0.0)

The version(`3.0.0`) is **not covered** by your current version range(`^2.49.3`).

<details>
<summary>Release Notes</summary>
<h1>v3.0.0</h1>
<h1><a href="https://github.com/gajus/eslint-plugin-flowtype/compare/v2.50.3...v3.0.0">3.0.0</a> (2018-10-13)</h1>
<h3>Features</h3>
<ul>
<li>add mixed to no-weak-types (<a href="https://github.com/gajus/eslint-plugin-flowtype/issues/362">#362</a>) (<a href="https://github.com/gajus/eslint-plugin-flowtype/commit/5e2bbe9">5e2bbe9</a>)</li>
</ul>
<h3>BREAKING CHANGES</h3>
<ul>
<li><code>mixed</code> is now treated as a weak type by default.</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: