### PR TITLE
Update eslint-plugin-node to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,9 +4042,9 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.49.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
-      "integrity": "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.0.0.tgz",
+      "integrity": "sha512-84utjHfQeykSyNuhO885pp18yGKYuK2S03EFbhl/BpXR9jk0TABnDP/KhUAqDjjkB43mxK2WZjJesrhnncvR9Q==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "flow-bin": "^0.75.0",


### PR DESCRIPTION
## Version **7.0.1** of **eslint-plugin-node** was just published.

* Package: [repository](https://github.com/mysticatea/eslint-plugin-node.git), [npm](https://www.npmjs.com/package/eslint-plugin-node)
* Current Version: 6.0.1
* Dev: true
* [compare 6.0.1 to 7.0.1 diffs](https://github.com/mysticatea/eslint-plugin-node/compare/v6.0.1...v7.0.1)

The version(`7.0.1`) is **not covered** by your current version range(`^6.0.1`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<h2>Bug fixes</h2>
<ul>
<li>It fixed false positive that the <code>node/no-unsupported-features/node-builtins</code> reports the <code>process.emitWarning</code> method on Node.js <code>>=6 &#x3C;8</code>. It was supported since Node.js 6.0.0.</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: