### PR TITLE
Update eslint-plugin-node to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,9 +4042,9 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.49.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
-      "integrity": "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.0.tgz",
+      "integrity": "sha512-baJmzngM6UKbEkJ5OY3aGw2zjXBt5L2QKZvTsOlXX7yHKIjNRrlJx2ods8Rng6EdqPR9rVNIQNYHpTs0qfn2qA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "flow-bin": "^0.75.0",


### PR DESCRIPTION
## Version **8.0.0** of **eslint-plugin-node** was just published.

* Package: [repository](https://github.com/mysticatea/eslint-plugin-node.git), [npm](https://www.npmjs.com/package/eslint-plugin-node)
* Current Version: 6.0.1
* Dev: true
* [compare 6.0.1 to 8.0.0 diffs](https://github.com/mysticatea/eslint-plugin-node/compare/v6.0.1...v8.0.0)

The version(`8.0.0`) is **not covered** by your current version range(`^6.0.1`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<p>This release focuses on supporting new things that were added between Node.js 8.7.0 and 11.0.0.</p>
<h2>Breaking changes</h2>
<ul>
<li><a href="https://github.com/Leko/hothouse/commit/58607951356dc63cd33366282eeda98ebd587dd0"><code>5860795</code></a> updated <code>node/no-deprecated-api</code> rule to disallow new deprecated APIs.<br>
Especially, it includes <a href="https://nodejs.org/dist/v11.0.0/docs/api/url.html#url_legacy_url_api">legacy URL API</a>.</li>
<li><a href="https://github.com/Leko/hothouse/commit/d153b93809c079b1be64aab706c14efb0da7991f"><code>d153b93</code></a> updated <code>node/no-unsupported-features/node-builtins</code> rule to detect new APIs.</li>
</ul>
<h2>New rules</h2>
<ul>
<li><a href="https://github.com/Leko/hothouse/commit/46ed54dc3931bbf78c6b6d0761201867c74c033f"><code>46ed54d</code></a> added <code>node/prefer-global/text-decoder</code> rule for new global varaible <code>TextDecoder</code>.</li>
<li><a href="https://github.com/Leko/hothouse/commit/46ed54dc3931bbf78c6b6d0761201867c74c033f"><code>46ed54d</code></a> added <code>node/prefer-global/text-encoder</code> rule for new global varaible <code>TextEncoder</code>.</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: