### PR TITLE
Update regenerator-runtime to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,16 +57,16 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-standard": "^3.1.0",
-    "flow-bin": "^0.75.0",
-    "husky": "^0.14.3",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
+    "flow-bin": "^0.89.0",
+    "husky": "^1.3.1",
     "jest": "^23.2.0",
     "lerna": "^3.0.3",
     "lerna-changelog": "^0.8.0",
     "prettier": "^1.13.5",
     "pretty-quick": "^1.6.0",
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.13.1"
   }
 }


### PR DESCRIPTION
## Version **0.13.1** of **regenerator-runtime** was just published.

* Package: [repository](https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime), [npm](https://www.npmjs.com/package/regenerator-runtime)
* Current Version: 0.12.0
* Dev: true


The version(`0.13.1`) is **not covered** by your current version range(`^0.12.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: