### PR TITLE
Update eslint-plugin-node to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,9 +4042,9 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.49.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
-      "integrity": "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.1.tgz",
+      "integrity": "sha512-1lymqM8Cawxu5xsS8TaCrLWJYUmUdoG4hCfa7yWOhCf0qZn/CvI8FxqkhdOP6bAosBn5zeYxKe3Q/4rfKN8a+A==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.10"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
     "flow-bin": "^0.75.0",


### PR DESCRIPTION
## Version **8.0.1** of **eslint-plugin-node** was just published.

* Package: [repository](https://github.com/mysticatea/eslint-plugin-node.git), [npm](https://www.npmjs.com/package/eslint-plugin-node)
* Current Version: 6.0.1
* Dev: true
* [compare 6.0.1 to 8.0.1 diffs](https://github.com/mysticatea/eslint-plugin-node/compare/v6.0.1...v8.0.1)

The version(`8.0.1`) is **not covered** by your current version range(`^6.0.1`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<h2>🐛 Bug fixes</h2>
<ul>
<li><a href="https://github.com/Leko/hothouse/commit/62ba6425a73845c235e93d706b7d826f70853c40"><code>62ba642</code></a> fixed the wrong messages of <code>node/no-deprecated-api</code> rule (<a href="https://github.com/Leko/hothouse/issues/142">#142</a>).</li>
<li><a href="https://github.com/Leko/hothouse/commit/0225b02d0f3f8dbf2d2d52577455bf9817e925ca"><code>0225b02</code></a>...<a href="https://github.com/Leko/hothouse/commit/0593c67576c86b2cbf4990db38d1cc4707b2f309"><code>0593c67</code></a> fixed the false positives of <code>no-unpublished-(bin|import|require)</code> rules (<a href="https://github.com/Leko/hothouse/issues/115">#115</a>, <a href="https://github.com/Leko/hothouse/issues/126">#126</a>).</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: