### PR TITLE
Update babel-jest to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4042,12 +4042,20 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.49.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
-      "integrity": "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.6.0.tgz",
+      "integrity": "sha512-7wRfgzXteB9jswXreGG64FlOdscV4z4hIW2lS+mC5t1K2QQkUDh7A+95dB4nU7io8zIOq4cRpftF+41xvMCtiA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/register": "^7.0.0-beta.51",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
-    "babel-jest": "^23.2.0",
+    "babel-jest": "^24.7.1",
     "can-npm-publish": "^1.3.1",
     "dotenv-cli": "^1.4.0",
     "eslint": "^5.0.0",


### PR DESCRIPTION
## Version **24.7.1** of **babel-jest** was just published.

* Package: [repository](https://github.com/facebook/jest.git), [npm](https://www.npmjs.com/package/babel-jest)
* Current Version: 23.2.0
* Dev: true
* [compare 23.2.0 to 24.7.1 diffs](https://github.com/facebook/jest/compare/v23.2.0...v24.7.1)

The version(`24.7.1`) is **not covered** by your current version range(`^23.2.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: