### PR TITLE
Update semver, semver to the latest version

### DIFF
--- a/packages/@hothouse/client-yarn/package-lock.json
+++ b/packages/@hothouse/client-yarn/package-lock.json
@@ -18,9 +18,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
       "dev": true
     }
   }

--- a/packages/@hothouse/client-yarn/package.json
+++ b/packages/@hothouse/client-yarn/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@hothouse/types": "^0.4.13",
-    "semver": "^5.5.0"
+    "semver": "^6.0.0"
   },
   "babel": {
     "extends": "../../../.babelrc"

--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -617,6 +617,13 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "npm-run-path": {
@@ -842,9 +849,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1123,6 +1130,13 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+            }
           }
         },
         "execa": {

--- a/packages/hothouse/package.json
+++ b/packages/hothouse/package.json
@@ -52,7 +52,7 @@
     "remark-github": "^7.0.3",
     "remark-html": "^9.0.0",
     "remark-parse": "^6.0.3",
-    "semver": "^5.5.0",
+    "semver": "^6.0.0",
     "threads": "^0.12.0",
     "unified": "^7.0.0",
     "yargs": "^12.0.1"


### PR DESCRIPTION
## Version **6.0.0** of **semver** was just published.

* Package: [repository](https://github.com/npm/node-semver.git), [npm](https://www.npmjs.com/package/semver)
* Current Version: 5.5.0
* Dev: false
* [compare 5.5.0 to 6.0.0 diffs](https://github.com/npm/node-semver/compare/v5.5.0...v6.0.0)

The version(`6.0.0`) is **not covered** by your current version range(`^5.5.0`).

Release note is not available


----------------------------------------

## Version **6.0.0** of **semver** was just published.

* Package: [repository](https://github.com/npm/node-semver.git), [npm](https://www.npmjs.com/package/semver)
* Current Version: 5.5.0
* Dev: true
* [compare 5.5.0 to 6.0.0 diffs](https://github.com/npm/node-semver/compare/v5.5.0...v6.0.0)

The version(`6.0.0`) is **not covered** by your current version range(`^5.5.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: