### PR TITLE
Update chalk to the latest version

### DIFF
--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -43,17 +43,23 @@
         "url-template": "^2.0.8"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+      "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
       }
     },
     "bail": {
@@ -101,13 +107,12 @@
       "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       }
     },
     "character-entities": {
@@ -151,17 +156,17 @@
       "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
     },
     "color-convert": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
-      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.1"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "comma-separated-tokens": {
       "version": "1.0.5",
@@ -214,11 +219,6 @@
       "requires": {
         "repeat-string": "^1.5.4"
       }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eventemitter3": {
       "version": "2.0.3",
@@ -281,9 +281,9 @@
       }
     },
     "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "hast-util-is-element": {
       "version": "1.0.2",
@@ -944,11 +944,11 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "threads": {

--- a/packages/hothouse/package.json
+++ b/packages/hothouse/package.json
@@ -39,7 +39,7 @@
     "@hothouse/monorepo-yarn-workspaces": "^0.4.13",
     "@hothouse/types": "^0.4.13",
     "@octokit/rest": "^16.2.0",
-    "chalk": "^2.4.1",
+    "chalk": "^3.0.0",
     "debug": "^4.0.1",
     "glob": "^7.1.2",
     "hosted-git-info": "^2.6.1",


### PR DESCRIPTION
## Version **3.0.0** of **chalk** was just published.

* Package: [repository](https://github.com/chalk/chalk.git), [npm](https://www.npmjs.com/package/chalk)
* Current Version: 2.4.1
* Dev: false
* [compare 2.4.1 to 3.0.0 diffs](https://github.com/chalk/chalk/compare/v2.4.1...v3.0.0)

The version(`3.0.0`) is **not covered** by your current version range(`^2.4.1`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<p><img src="https://user-images.githubusercontent.com/170270/68524554-0d375b80-02fb-11ea-97a9-27e15fc8ccc6.gif" width="250" height="250" align="right"> <strong>This release has been in development for more than a year and <a href="https://github.com/chalk/chalk/pull/337">massively improves performance</a> and <a href="https://github.com/chalk/chalk/pull/358">the time it takes to import Chalk</a>.</strong></p>
<p>Thanks to <a href="https://github.com/stroncium"><strong>@stroncium</strong></a> for his hard work on this. 🙌</p>
<h3>Breaking</h3>
<ul>
<li>Require Node.js 8  <a href="https://github.com/Leko/hothouse/commit/3ef170b"><code>3ef170b</code></a></li>
<li>Remove the <code>.enabled</code> property in favor of <a href="https://github.com/chalk/chalk#chalklevel"><code>.level</code></a> (<a href="https://github.com/Leko/hothouse/issues/356">#356</a>)  <a href="https://github.com/Leko/hothouse/commit/1f77953"><code>1f77953</code></a>
- Why: It was confusing to users to have two properties for detecting color support.
- Migrate:</li>
</ul>
<pre><code class="language-diff">-if (chalk.enabled) {}
+if (chalk.level > 0) {}
</code></pre>
<ul>
<li>Remove <code>chalk.constructor()</code> in favor of <code>chalk.Instance()</code> (<a href="https://github.com/Leko/hothouse/issues/322">#322</a>)  <a href="https://github.com/Leko/hothouse/commit/de2f4cd"><code>de2f4cd</code></a>
- Migrate:</li>
</ul>
<pre><code class="language-diff">-new chalk.constructor({level: 1});
+new chalk.Instance({level: 1})
</code></pre>
<h3>Minor breaking</h3>
<ul>
<li>Use CommonJS-compatible export in TypeScript definition (<a href="https://github.com/Leko/hothouse/issues/344">#344</a>)  <a href="https://github.com/Leko/hothouse/commit/98628d9"><code>98628d9</code></a>
- Why: Faking default export for TypeScript <a href="https://github.com/sindresorhus/mem/issues/31">broke IntelliSense for JavaScript</a>.
- Migrate:</li>
</ul>
<pre><code class="language-diff">-import chalk from 'chalk';
+import chalk = require('chalk');
</code></pre>
<p>Or if you have <code>esModuleInterop</code> enabled:</p>
<pre><code class="language-diff">-import chalk from 'chalk';
+import * as chalk from 'chalk';
</code></pre>
<ul>
<li>Drop built-in Flow type definition  <a href="https://github.com/Leko/hothouse/commit/d3be9c6"><code>d3be9c6</code></a>
- Why: None of us use Flow and we were not good at maintaining the type definition. You can get the types at <a href="https://github.com/flow-typed/flow-typed">flow-typed</a> <em>(needs to be updated to Chalk v3, open an issue on <code>flow-typed</code>)</em>.</li>
<li>Rename the <code>ChalkOptions</code> TypeScript type to <code>Options</code> <a href="https://github.com/Leko/hothouse/commit/cf66156"><code>cf66156</code></a></li>
<li>Remove <code>dim</code> style workaround for Windows (<a href="https://github.com/Leko/hothouse/issues/331">#331</a>)  <a href="https://github.com/Leko/hothouse/commit/cd5de7a"><code>cd5de7a</code></a>
- Why: The issue was fixed in newer Windows 10 builds.</li>
<li>Remove the <code>blue</code> color workaround for Windows (<a href="https://github.com/Leko/hothouse/issues/330">#330</a>)  <a href="https://github.com/Leko/hothouse/commit/2ca015c"><code>2ca015c</code></a>
- Why: The issue was fixed in newer Windows 10 builds.</li>
</ul>
<h3>Enhancements</h3>
<ul>
<li>Massively improve performance! (<a href="https://github.com/Leko/hothouse/issues/337">#337</a>)  <a href="https://github.com/Leko/hothouse/commit/c08417e"><code>c08417e</code></a></li>
<li>Improve require speed (<a href="https://github.com/Leko/hothouse/issues/358">#358</a>)  <a href="https://github.com/Leko/hothouse/commit/61aca7c"><code>61aca7c</code></a></li>
<li>Add <a href="https://github.com/chalk/chalk#chalkstderr-and-chalkstderrsupportscolor"><code>chalk.stderr</code></a> for printing to stderr (<a href="https://github.com/Leko/hothouse/issues/359">#359</a>)  <a href="https://github.com/Leko/hothouse/commit/2a53389"><code>2a53389</code></a></li>
<li>Add <code>blackBright</code> color. It's the same as the <code>gray</code> color, but added for consistency. <a href="https://github.com/Leko/hothouse/commit/c25c32a"><code>c25c32a</code></a></li>
<li>Fix support for bracketed Unicode escapes in template literals (<a href="https://github.com/Leko/hothouse/issues/350">#350</a>)  <a href="https://github.com/Leko/hothouse/commit/9830948"><code>9830948</code></a></li>
<li>Export TypeScript types for colors and modifiers (<a href="https://github.com/Leko/hothouse/issues/357">#357</a>)  <a href="https://github.com/Leko/hothouse/commit/6b4d206"><code>6b4d206</code></a></li>
<li>Add <code>ansi256</code> and <code>bgAnsi256</code> to TypeScript declaration (<a href="https://github.com/Leko/hothouse/issues/368">#368</a>)  <a href="https://github.com/Leko/hothouse/commit/fb8e85a"><code>fb8e85a</code></a></li>
<li>Add <code>ansi</code> and <code>bgAnsi</code> to TypeScript declaration (<a href="https://github.com/Leko/hothouse/issues/369">#369</a>)  <a href="https://github.com/Leko/hothouse/commit/18c280d"><code>18c280d</code></a></li>
</ul>
<h3>Color detection</h3>
<ul>
<li>The <code>FORCE_COLOR</code> environment variable can now be used to force a certain color level (<a href="https://github.com/Leko/hothouse/issues/315">#315</a>)  <a href="https://github.com/Leko/hothouse/commit/af4a078"><code>af4a078</code></a></li>
<li>Add support for GitHub Actions in the color detection <a href="https://github.com/chalk/supports-color/commit/79d13032e2aa7a011f1c8badc866bcf4bc500f7a">chalk/supports-color@<code>79d1303</code></a></li>
<li>Give <code>TERM=dumb</code> higher priority in the color detection <a href="https://github.com/chalk/supports-color/commit/8d6a7b5830a96858a95ce9cfee1840dc30a3e837">chalk/supports-color@<code>8d6a7b5</code></a></li>
<li>Add support for VT220 in the color detection <a href="https://github.com/chalk/supports-color/commit/ed0fe39d600ff1c286b3948abbef88eaef4f8f27">chalk/supports-color@<code>ed0fe39</code></a></li>
</ul>
<h3>Fixes</h3>
<ul>
<li>Fix support for nested styles (<a href="https://github.com/Leko/hothouse/issues/335">#335</a>)  <a href="https://github.com/Leko/hothouse/commit/87156ce"><code>87156ce</code></a></li>
<li>Fix const enum for TypeScript (<a href="https://github.com/Leko/hothouse/issues/364">#364</a>)  <a href="https://github.com/Leko/hothouse/commit/4e65299"><code>4e65299</code></a></li>
<li>Fix TypeScript type for <code>supportsColor</code> which is top‑level only (<a href="https://github.com/Leko/hothouse/issues/342">#342</a>)  <a href="https://github.com/Leko/hothouse/commit/b3e9b91"><code>b3e9b91</code></a></li>
<li>Fix TypeScript type for <code>chalk.supportsColor</code> (<a href="https://github.com/Leko/hothouse/issues/347">#347</a>)  <a href="https://github.com/Leko/hothouse/commit/d82b2a6"><code>d82b2a6</code></a></li>
<li>Fix TypeScript type for tagged template literal argument to accept <code>unknown</code> instead of just <code>string</code> (<a href="https://github.com/Leko/hothouse/issues/316">#316</a>)  <a href="https://github.com/Leko/hothouse/commit/7f6e563"><code>7f6e563</code></a></li>
</ul>
<p><a href="https://github.com/chalk/chalk/compare/v2.4.1...v3.0.0">https://github.com/chalk/chalk/compare/v2.4.1...v3.0.0</a></p>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: