### PR TITLE
Update babel-jest to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1721,6 +1722,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4042,12 +4044,20 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "2.49.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz",
-      "integrity": "sha512-wO0S4QbXPReKtydxbY5A0UieOaF9jBO5BMuxYPQOTa082JCpKEoC7+o3fnKsVVycwX47lvqLiUGRsWauCiA9aw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
+      "integrity": "sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {
@@ -7291,7 +7301,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/register": "^7.0.0-beta.51",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
-    "babel-jest": "^23.2.0",
+    "babel-jest": "^24.9.0",
     "can-npm-publish": "^1.3.1",
     "dotenv-cli": "^1.4.0",
     "eslint": "^5.0.0",


### PR DESCRIPTION
## Version **24.9.0** of **babel-jest** was just published.

* Package: [repository](https://github.com/facebook/jest.git), [npm](https://www.npmjs.com/package/babel-jest)
* Current Version: 23.2.0
* Dev: true
* [compare 23.2.0 to 24.9.0 diffs](https://github.com/facebook/jest/compare/v23.2.0...v24.9.0)

The version(`24.9.0`) is **not covered** by your current version range(`^23.2.0`).

<details>
<summary>Release Notes</summary>
<h1>24.9.0</h1>
<h3>Features</h3>
<ul>
<li><code>[expect]</code> Highlight substring differences when matcher fails, part 1 (<a href="https://github.com/facebook/jest/pull/8448">#8448</a>)</li>
<li><code>[expect]</code> Highlight substring differences when matcher fails, part 2 (<a href="https://github.com/facebook/jest/pull/8528">#8528</a>)</li>
<li><code>[expect]</code> Improve report when mock-spy matcher fails, part 1 (<a href="https://github.com/facebook/jest/pull/8640">#8640</a>)</li>
<li><code>[expect]</code> Improve report when mock-spy matcher fails, part 2 (<a href="https://github.com/facebook/jest/pull/8649">#8649</a>)</li>
<li><code>[expect]</code> Improve report when mock-spy matcher fails, part 3 (<a href="https://github.com/facebook/jest/pull/8697">#8697</a>)</li>
<li><code>[expect]</code> Improve report when mock-spy matcher fails, part 4 (<a href="https://github.com/facebook/jest/pull/8710">#8710</a>)</li>
<li><code>[expect]</code> Throw matcher error when received cannot be jasmine spy (<a href="https://github.com/facebook/jest/pull/8747">#8747</a>)</li>
<li><code>[expect]</code> Improve report when negative CalledWith assertion fails (<a href="https://github.com/facebook/jest/pull/8755">#8755</a>)</li>
<li><code>[expect]</code> Improve report when positive CalledWith assertion fails (<a href="https://github.com/facebook/jest/pull/8771">#8771</a>)</li>
<li><code>[expect]</code> Display equal values for ReturnedWith similar to CalledWith (<a href="https://github.com/facebook/jest/pull/8791">#8791</a>)</li>
<li><code>[expect, jest-snapshot]</code> Change color from green for some args in matcher hints (<a href="https://github.com/facebook/jest/pull/8812">#8812</a>)</li>
<li><code>[jest-snapshot]</code> Highlight substring differences when matcher fails, part 3 (<a href="https://github.com/facebook/jest/pull/8569">#8569</a>)</li>
<li><code>[jest-core]</code> Improve report when snapshots are obsolete (<a href="https://github.com/facebook/jest/pull/8665">#8448</a>)</li>
<li><code>[jest-cli]</code> Improve chai support (with detailed output, to match jest exceptions) (<a href="https://github.com/facebook/jest/pull/8454">#8454</a>)</li>
<li><code>[*]</code> Manage the global timeout with <code>--testTimeout</code> command line argument. (<a href="https://github.com/facebook/jest/pull/8456">#8456</a>)</li>
<li><code>[pretty-format]</code> Render custom displayName of memoized components</li>
<li><code>[jest-validate]</code> Allow <code>maxWorkers</code> as part of the <code>jest.config.js</code> (<a href="https://github.com/facebook/jest/pull/8565">#8565</a>)</li>
<li><code>[jest-runtime]</code> Allow passing configuration objects to transformers (<a href="https://github.com/facebook/jest/pull/7288">#7288</a>)</li>
<li><code>[@jest/core, @jest/test-sequencer]</code> Support async sort in custom <code>testSequencer</code> (<a href="https://github.com/facebook/jest/pull/8642">#8642</a>)</li>
<li><code>[jest-runtime, @jest/fake-timers]</code> Add <code>jest.advanceTimersToNextTimer</code> (<a href="https://github.com/facebook/jest/pull/8713">#8713</a>)</li>
<li><code>[@jest-transform]</code> Extract transforming require logic within <code>jest-core</code> into <code>@jest-transform</code> (<a href="https://github.com/facebook/jest/pull/8756">#8756</a>)</li>
<li><code>[jest-matcher-utils]</code> Add color options to <code>matcherHint</code> (<a href="https://github.com/facebook/jest/pull/8795">#8795</a>)</li>
<li><code>[jest-circus/jest-jasmine2]</code> Give clearer output for Node assert errors (<a href="https://github.com/facebook/jest/pull/8792">#8792</a>)</li>
<li><code>[jest-runner]</code> Export all types in the type signature of <code>jest-runner</code> (<a href="https://github.com/facebook/jest/pull/8825">#8825</a>)`</li>
</ul>
<h3>Fixes</h3>
<ul>
<li><code>[jest-cli]</code> Detect side-effect only imports when running <code>--onlyChanged</code> or <code>--changedSince</code> (<a href="https://github.com/facebook/jest/pull/8670">#8670</a>)</li>
<li><code>[jest-cli]</code> Allow <code>--maxWorkers</code> to work with % input again (<a href="https://github.com/facebook/jest/pull/8565">#8565</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Expand list of whitelisted globals in global mocks (<a href="https://github.com/facebook/jest/pull/8429">#8429</a></li>
<li><code>[jest-core]</code> Make watch plugin initialization errors look nice (<a href="https://github.com/facebook/jest/pull/8422">#8422</a>)</li>
<li><code>[jest-snapshot]</code> Prevent inline snapshots from drifting when inline snapshots are updated (<a href="https://github.com/facebook/jest/pull/8492">#8492</a>)</li>
<li><code>[jest-haste-map]</code> Don't throw on missing mapper in Node crawler (<a href="https://github.com/facebook/jest/pull/8558">#8558</a>)</li>
<li><code>[jest-core]</code> Fix incorrect <code>passWithNoTests</code> warning (<a href="https://github.com/facebook/jest/pull/8595">#8595</a>)</li>
<li><code>[jest-snapshots]</code> Fix test retries that contain snapshots (<a href="https://github.com/facebook/jest/pull/8629">#8629</a>)</li>
<li><code>[jest-mock]</code> Fix incorrect assignments when restoring mocks in instances where they originally didn't exist (<a href="https://github.com/facebook/jest/pull/8631">#8631</a>)</li>
<li><code>[expect]</code> Fix stack overflow when matching objects with circular references (<a href="https://github.com/facebook/jest/pull/8687">#8687</a>)</li>
<li><code>[jest-haste-map]</code> Workaround a node >=12.5.0 bug that causes the process not to exit after tests have completed and cancerous memory growth (<a href="https://github.com/facebook/jest/pull/8787">#8787</a>)</li>
</ul>
<h3>Chore &#x26; Maintenance</h3>
<ul>
<li><code>[jest-leak-detector]</code> remove code repeat (<a href="https://github.com/facebook/jest/pull/8438">#8438</a></li>
<li><code>[docs]</code> Add example to <code>jest.requireActual</code> (<a href="https://github.com/facebook/jest/pull/8482">#8482</a></li>
<li><code>[docs]</code> Add example to <code>jest.mock</code> for mocking ES6 modules with the <code>factory</code> parameter (<a href="https://github.com/facebook/jest/pull/8550">#8550</a>)</li>
<li><code>[docs]</code> Add information about using <code>jest.doMock</code> with ES6 imports (<a href="https://github.com/facebook/jest/pull/8573">#8573</a>)</li>
<li><code>[docs]</code> Fix variable name in custom-matcher-api code example (<a href="https://github.com/facebook/jest/pull/8582">#8582</a>)</li>
<li><code>[docs]</code> Fix example used in custom environment docs (<a href="https://github.com/facebook/jest/pull/8617">#8617</a>)</li>
<li><code>[docs]</code> Updated react tutorial to refer to new package of react-testing-library (<a href="https://github.com/testing-library/react"><strong>@testing-library/react</strong></a>) (<a href="https://github.com/facebook/jest/pull/8753">#8753</a>)</li>
<li><code>[docs]</code> Updated imports of react-testing-library to <a href="https://github.com/testing-library/react"><strong>@testing-library/react</strong></a> in website (<a href="https://github.com/facebook/jest/pull/8757">#8757</a>)</li>
<li><code>[jest-core]</code> Add <code>getVersion</code> (moved from <code>jest-cli</code>) (<a href="https://github.com/facebook/jest/pull/8706">#8706</a>)</li>
<li><code>[docs]</code> Fix MockFunctions example that was using toContain instead of toContainEqual (<a href="https://github.com/facebook/jest/pull/8765">#8765</a>)</li>
<li><code>[*]</code> Make sure copyright header comment includes license (<a href="https://github.com/facebook/jest/pull/8783">#8783</a>)</li>
<li><code>[*]</code> Check copyright and license as one joined substring (<a href="https://github.com/facebook/jest/pull/8815">#8815</a>)</li>
<li><code>[docs]</code> Fix WatchPlugins <code>jestHooks.shouldRunTestSuite</code> example that receives an object (<a href="https://github.com/facebook/jest/pull/8784">#8784</a>)</li>
<li><code>[*]</code> Enforce LF line endings (<a href="https://github.com/facebook/jest/pull/8809">#8809</a>)</li>
<li><code>[pretty-format]</code> Delete obsolete link and simplify structure in README (<a href="https://github.com/facebook/jest/pull/8824">#8824</a>)</li>
</ul>
<h3>Performance</h3>
<ul>
<li><code>[jest-watcher]</code> Minor optimization for JestHook (<a href="https://github.com/facebook/jest/pull/8746">#8746</a></li>
<li><code>[@jest/reporters]</code> Prevent runaway CPU useage with <code>--notify</code> on macOS (<a href="https://github.com/facebook/jest/issues/8830">#8830</a>)</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: