### PR TITLE
Update mustache to the latest version

### DIFF
--- a/packages/hothouse/package-lock.json
+++ b/packages/hothouse/package-lock.json
@@ -665,9 +665,9 @@
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mustache": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.0.tgz",
-      "integrity": "sha512-bhBDkK/PioIbtQzRIbGUGypvc3MC4c389QnJt8KDIEJ666OidRPoXAQAHPivikfS3JkMEaWoPvcDL7YrQxtSwg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.0.tgz",
+      "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA=="
     },
     "native-promise-only": {
       "version": "0.8.1",

--- a/packages/hothouse/package.json
+++ b/packages/hothouse/package.json
@@ -45,7 +45,7 @@
     "hosted-git-info": "^3.0.2",
     "lodash": "^4.17.10",
     "minimatch": "^3.0.4",
-    "mustache": "^3.0.0",
+    "mustache": "^4.0.0",
     "node-emoji": "^1.8.1",
     "normalize-package-data": "^2.4.0",
     "remark": "^10.0.1",


### PR DESCRIPTION
## Version **4.0.0** of **mustache** was just published.

* Package: [repository](https://github.com/janl/mustache.js.git), [npm](https://www.npmjs.com/package/mustache)
* Current Version: 3.0.0
* Dev: false
* [compare 3.0.0 to 4.0.0 diffs](https://github.com/janl/mustache.js/compare/v3.0.0...v4.0.0)

The version(`4.0.0`) is **not covered** by your current version range(`^3.0.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: